### PR TITLE
Troubleshooting dataset.mode typo bug when saving_img

### DIFF
--- a/classy_track.py
+++ b/classy_track.py
@@ -235,7 +235,7 @@ def detect(opt, *args):
             # Save video results
             if save_img:
                 print('saving img!')
-                if dataset.mode == 'images':
+                if dataset.mode == 'image':
                     cv2.imwrite(save_path, im0)
                 else:
                     print('saving video!')


### PR DESCRIPTION
When executing the command below.

```bash
python classy_track.py --source <IMG_PATH> --save-img
```

Get below error... 

```txt
Traceback (most recent call last):
  File "classy_track.py", line 306, in <module>
    detect(args)
  File "classy_track.py", line 247, in detect
    fps = vid_cap.get(cv2.CAP_PROP_FPS)
AttributeError: 'NoneType' object has no attribute 'get'
```